### PR TITLE
chore(cd): Update redirect syntax

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,7 +39,7 @@ jobs:
             cargo publish --verbose
           else  
             if $DRY_RUN == true; then
-              echo $ARGS $DRY_RUN >> $ARGS
+              echo ARGS=$ARGS $DRY_RUN >> $GITHUB_ENV
             fi
 
             cargo publish $ARGS


### PR DESCRIPTION
Previously, I'd misunderstood how environment variables are treated within GitHub actions, and this should correct their usage within the CD worlflow file.