### PR TITLE
chore(ci): Add step validating ignored tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
       run: cargo fmt --check --verbose
     - name: Validate Clippy
       run: cargo clippy -- -D warnings --verbose
-    - name: Validate Tests
+    - name: Validate Standard Tests
       run: cargo test --verbose
+    # As this file is running tests on a library for generating tests,
+    # it's required that it run tests on both standard tests,
+    # and ignored cases, as generating such tests, is included in it's expected bahaviour...
+    - name: Validate Ignored Tests
+      run: cargo test --verbose -- --ignored
 


### PR DESCRIPTION
As noted in a comment in the modified file, this commit updates the CI for this project once again, to add a step to run test cases with the `ignore` attribute, as this library is dedicated to a testing tool, meaning creating ignored tests should be part of it's expected behaviour...