### PR TITLE
tests: Remove then_some Usage

### DIFF
--- a/tests/doctest_example_termination.rs
+++ b/tests/doctest_example_termination.rs
@@ -22,7 +22,11 @@ mod block_wide {
     use test_gen::test_gen;
 
     fn clamp_result(a: u32) -> Result<(), ()> {
-        (1..101).contains(&a).then_some(()).ok_or(())
+        if (1..101).contains(&a) {
+            Ok(())
+        } else {
+            Err(())
+        }
     }
 
     test_gen! {


### PR DESCRIPTION
This will remove the use of the `then_some` method from tests, as it currently causes the CI to fail on the MSRV toolchain test, as the feature was stabilised in version, 1.62.0, with MSRV set to 1.61.0...