### PR TITLE
ci(cd): Add release exception + Comment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,10 @@ env:
 
 jobs:
   validate-release:
-    if: ${{ !contains(inputs.args, '--token') && github.ref_name == 'main' }}
+    # Restricts the workflow to running, only if:
+    # 1. It isn't potentially expose a token, and is against the main branch
+    # 2. It's triggered by a release
+    if: ${{ !contains(inputs.args, '--token') && github.ref_name == 'main' || github.event_name == 'release' }}
     uses: ./.github/workflows/ci.yml
   publish-release:
     needs: validate-release


### PR DESCRIPTION
Previously, it turned out my checks as to whether to halt the CD workflow, were designed around the `workflow_dispatch` trigger type, meaning it wouldn't run for releases, as intended...

This should hopefully remedy this, so if this workflow is ever properly used again, there will be an exception so it runs when a release is created...