### PR TITLE
tests(README): Add text type annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Documentation can be found at [Docs.rs].
 **Minimum Supported Rust Version:** 1.63.0
 
 `test_gen` can be added to a project, using the following command:
-```
+```text
 cargo add test_gen --dev
 ```
 


### PR DESCRIPTION
Embarrassingly, I neglected the fact `rustdoc` compiles text in code-blocks as Rust code, unless specified otherwise, and that it was set up the include the `README.md` file as dummy documentation, causing it's tests to fail when attempting to compile the command example...

This should fix the mistake, by adding a `text` annotation to the block...