### PR TITLE
ci(ci): Add README to validated files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: "main"
     paths:
+      # `README.md` is included in `src/lib.rs` as a doc comment,
+      # meaning any changes potentially affecting it's code running,
+      # should be validated..
+      - "README.md"
       - "**.rs"
       - "**.toml"
     types:


### PR DESCRIPTION
After bungling my recent release, I realised including the `README.md` as a doc comment in `src/lib.rs`, means `rustdoc` will attempt to validate any unannotated code blocks, by compiling them as Rust code.

Consequently, this means any pull requests with changes to the `README.md` file, should be validated, in-case they potentially break included code examples...