### PR TITLE
refactor(lib): Tweak TestHelper Parse method chain

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,8 +257,7 @@ impl Parse for TestHelper {
         let cases = cases
             .is_empty()
             .then(|| Error::new(cases.span(), "expected test cases"))
-            .map(Result::Err) // Wrapping the error with a `map` format more cleanly...
-            .unwrap_or_else(|| cases.parse_terminated(TestCase::parse))?;
+            .map_or_else(|| cases.parse_terminated(TestCase::parse), Result::Err)?;
 
         let out = TestHelper {
             static_attrs,


### PR DESCRIPTION
Whilst working on a previous commit, refactoring the implementation of the top-level `test_gen` proc-macro function, I was reminded of a method style which would allow the combinations of the `Option::map` and `Option::unwrap_or_else` methods, into a single method call, with the use of `Option::map_or_else`. This is only a minor commit, to implement this improvement.