### PR TITLE
refactor(lib): Update Parse impls using Result::map

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,11 +436,10 @@ impl Parse for FnArgs {
         // Using `punctuated::parse_separated_nonempty` in this case,
         // because if this type is being parsed, arguments should be expected,
         // and trailing commas look sloppy...
-        let args = inner
+        inner
             .call(Punctuated::parse_separated_nonempty)
-            .map_err(|err| Error::new(err.span(), "expected function arguments"))?;
-
-        Ok(Self { parens, args })
+            .map_err(|err| Error::new(err.span(), "expected function arguments"))
+            .map(|args| Self { parens, args })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,15 +350,12 @@ impl Parse for TestCase {
             .parse()
             .map_err(|err| Error::new(err.span(), "expected test case name"))?;
         let colon = input.parse()?;
-        let args = input.parse()?;
 
-        let out = TestCase {
+        input.parse().map(|args| Self {
             fn_name,
             colon,
             args,
-        };
-
-        Ok(out)
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,11 +472,10 @@ impl Parse for ReturnType {
 
         // Default error message is a bit obtuse in this case,
         // so it's mapped to a more specific bespoke error instead.
-        let return_type = input
+        input
             .parse()
-            .map_err(|err| Error::new(err.span(), "expected a return type"))?;
-
-        Ok(Self { arrow, return_type })
+            .map_err(|err| Error::new(err.span(), "expected a return type"))
+            .map(|return_type| Self { arrow, return_type })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,6 +244,7 @@ impl Parse for TestHelper {
         let farrow = input.parse()?;
         let cases;
         let braces = braced!(cases in input);
+
         // If the contents of the`cases` is empty,
         // `ParseBuffer::parse_terminated` will simply produce an empty
         // `Punctuated` struct, and no error. On the other hand,
@@ -254,23 +255,20 @@ impl Parse for TestHelper {
         // Instead, its explicitly checked whether `cases` is empty,
         // resulting in a bespoke error which provides an explanation which is actually
         // helpful.
-        let cases = cases
+        cases
             .is_empty()
             .then(|| Error::new(cases.span(), "expected test cases"))
-            .map_or_else(|| cases.parse_terminated(TestCase::parse), Result::Err)?;
-
-        let out = TestHelper {
-            static_attrs,
-            separator,
-            helper,
-            static_args,
-            static_return_type,
-            farrow,
-            braces,
-            cases,
-        };
-
-        Ok(out)
+            .map_or_else(|| cases.parse_terminated(TestCase::parse), Result::Err)
+            .map(|cases| Self {
+                static_attrs,
+                separator,
+                helper,
+                static_args,
+                static_return_type,
+                farrow,
+                braces,
+                cases,
+            })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,16 +400,13 @@ impl Parse for CaseArgs {
         }
 
         let args = inner.parse()?;
-        let return_type = inner.call(ReturnType::try_parse)?;
 
-        let out = CaseArgs {
+        inner.call(ReturnType::try_parse).map(|return_type| Self {
             braces,
             attrs,
             args,
             return_type,
-        };
-
-        Ok(out)
+        })
     }
 }
 


### PR DESCRIPTION
Whilst this change affects the structure of the code, it is primarily a stylistic change.

When writing the implementations for `Parse::parse`, result propagation was used throughout the functions for handling cases of failed parsing, including for the final element parsed in the function...

With these commits, I've decided to change this style, rather than unwrapping the result of the function, a stylistic change will be made to instead use `Result::map`, to expose the parsed value, and use it to produce the resulting struct.