### PR TITLE
docs(lib): Add comment on destructuring

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,9 @@ struct TestHelper {
 impl TestHelper {
     /// Produces the tokens for the test cases represented by the value.
     fn restructure(self) -> TokenStream2 {
+        // Uses destructuring, due to use `self`,
+        // not being supported in quoting macros,
+        // as well as allowing for the consumption of `cases`.
         let Self {
             static_attrs,
             helper,


### PR DESCRIPTION
Adds a comment in `TestHelper::restructure`, on the reasoning for the use of destructuring in the method.