### PR TITLE
docs(lib): Comment optional static args parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,9 @@ impl Parse for MacroHelper {
         let helper = input
             .parse()
             .map_err(|err| Error::new(err.span(), "expected helper function"))?;
+
+        // Parsing is only attempted, if parenthese are peeked,
+        // as this would indicate the user wishes to specify static args.
         let static_args = input.peek(Paren).then(|| input.parse()).transpose()?;
         let static_return_type = input.call(ReturnType::try_parse)?;
         let farrow = input.parse()?;


### PR DESCRIPTION
Had a moment of confusion looking back over my code after noticing a use of `Option::transpose`, due to the fact I'd moved a similar pattern when parsing instances of the `ReturnType` struct, to an associated function, when it was for the optional parsing of static args in this case...

Due to this, I'm adding a small comment to clarify at a glance, that the usage in this case, is intentional.