### PR TITLE
ci(ci): Ignore draft PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - ready_for_review
   workflow_call:
 
 env:
@@ -22,6 +23,7 @@ env:
 jobs:    
   validate-pull:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request }}
     strategy:
       matrix:
         toolchain:


### PR DESCRIPTION
Updates the CI, to check whether a PR is a draft, to ensure CI only runs for PRs which are intended to be merged.